### PR TITLE
feat: introduce custom logger

### DIFF
--- a/backend/pkg/go.mod
+++ b/backend/pkg/go.mod
@@ -5,6 +5,7 @@ go 1.23.3
 require (
 	cloud.google.com/go/firestore v1.18.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/manaaan/ekolivs-oms/product v0.0.0-00010101000000-000000000000
 	github.com/oapi-codegen/runtime v1.1.1
@@ -23,7 +24,6 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.54.0 // indirect

--- a/backend/pkg/tlog/README.md
+++ b/backend/pkg/tlog/README.md
@@ -1,0 +1,37 @@
+## Custom GCP logger
+
+Package logger offers structured logging that complies with the W3C Trace Context standard, integrating
+distributed tracing via the `traceparent` header.
+
+:exclamation: `traceparent` has a special format that consists of the following:
+
+```
+version-traceid-parentid-flags
+```
+
+`traceid` allows correlation of all operations under a single transaction across multiple systems.
+
+### Logger Package for gRPC Calls
+
+In the case of gRPC calls, our logger package (pkg/log) is designed to handle `traceparent` IDs and will attempt to extract it from gRPC metadata.
+
+The context when creating a new logger instance contains the logger itself and prepares it for future gRPC calls to chain through the traceparent for correlating the logs for troubleshooting.
+
+### Usage
+
+#### Log messages
+
+To log messages, initiate the logger with a context containing traceparent.
+
+```go
+log, ctx := tlog.New(context.Background())
+log.Info("Processing request", "method", req.Method, "path", req.URL.Path)
+```
+
+#### Making gRPC calls
+
+Continue using the context enriched with gRPC metadata. However, ensure that it now includes the traceparent value.
+
+```go
+ctx := tlog.GetGRPCContext(req)
+```

--- a/backend/pkg/tlog/tlog.go
+++ b/backend/pkg/tlog/tlog.go
@@ -1,0 +1,80 @@
+// Package logger offers structured logging for GCP that complies with the W3C Trace Context standard, integrating
+// distributed tracing via the `traceparent` header.
+
+// Features:
+// - Extracts `traceparent` from HTTP/gRPC for correlated logs.
+// - Generates UUID for logs without `traceparent`.
+// - Integrates with HTTP and gRPC services.
+// - Logs source information where the error was logged from
+// - Integrates to GCP severity levels to be categorized correctly
+
+// Usage Example:
+//
+//	func handler(w http.ResponseWriter, r *http.Request) {
+//	    log, ctx := tlog.New(context.Background())
+//	    log.Info("Handling request", "path", r.URL.Path)
+//	}
+package tlog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/manaaan/ekolivs-oms/pkg/tlog/traceparent"
+	"google.golang.org/grpc/metadata"
+)
+
+// Unique type to avoid conflict on ctx values
+type Logger string
+
+const Key Logger = "logger"
+
+// New creates a new logger instance prioritizing data extraction from gRPC metadata,
+// falling back to HTTP context or a fallback.
+func New(ctx context.Context) (*slog.Logger, context.Context) {
+	var traceParent string
+
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		// Attempt to extract traceparent from gRPC metadata
+		if values := md.Get(string(traceparent.Key)); len(values) > 0 {
+			traceParent = values[0]
+		}
+	}
+
+	// Fallback to extracting traceParent from the regular context, falling back to new UUID.
+	if traceParent == "" {
+		traceParent, _ = traceparent.TraceParentFromContext(ctx)
+	}
+
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource: true,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.LevelKey {
+				// Rename the level key from "level" to "severity", to have GCP interpret it correctly
+				a.Key = "severity"
+			}
+			if a.Key == slog.SourceKey {
+				// Hijacking the source key with a slimmed string value instead of the json group.
+				// If we want all fields from AddSource we should rename the key to "sourceLocation"
+				// for better logging in GCP as defined here: https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields
+				if src, ok := a.Value.Any().(*slog.Source); ok {
+					// Get the two levels above the base file name
+					dir, file := filepath.Split(src.File)
+					parentDir := filepath.Base(dir)
+					grandparentDir := filepath.Base(filepath.Dir(filepath.Dir(dir)))
+					a.Value = slog.StringValue(fmt.Sprintf("%s/%s/%s:%d", grandparentDir, parentDir, file, src.Line))
+				}
+			}
+			return a
+		}}))
+
+	logger := log.With(slog.String("traceparent", traceParent))
+
+	ctx = context.WithValue(ctx, Key, logger)
+	grpcCtx := traceparent.GetGRPCContext(ctx, traceParent)
+
+	return logger, grpcCtx
+}

--- a/backend/pkg/tlog/traceparent/traceparent.go
+++ b/backend/pkg/tlog/traceparent/traceparent.go
@@ -1,0 +1,43 @@
+package traceparent
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/metadata"
+)
+
+// Unique type to avoid conflict on ctx values
+type TraceParent string
+
+const Key TraceParent = "traceparent"
+
+// GenerateCorrelationID generates a new UUID for use as a Correlation ID.
+func GenerateTraceParent() string {
+	return uuid.New().String()
+}
+
+// TraceParentFromContext retrieves the TraceParent from the context
+// or generating a UUID if missing.
+func TraceParentFromContext(ctx context.Context) (string, error) {
+	if ctx == nil {
+		return GenerateTraceParent(), errors.New("context is nil in TraceParentFromContext")
+	}
+
+	traceParent, ok := ctx.Value(Key).(string)
+	if !ok {
+		return GenerateTraceParent(), errors.New("traceparent is not set or not a string in TraceParentFromContext")
+	}
+
+	return traceParent, nil
+}
+
+// GetGRPCContext returns a context with the correlation ID from the request
+// Used for gRPC calls
+func GetGRPCContext(ctx context.Context, traceparent string) context.Context {
+	headers := map[string]string{}
+	headers[string(Key)] = traceparent
+	md := metadata.New(headers)
+	return metadata.NewOutgoingContext(ctx, md)
+}

--- a/backend/services/product/internal/server/server.go
+++ b/backend/services/product/internal/server/server.go
@@ -2,8 +2,8 @@ package server
 
 import (
 	"context"
-	"log/slog"
 
+	"github.com/manaaan/ekolivs-oms/pkg/tlog"
 	"github.com/manaaan/ekolivs-oms/product/api"
 	"github.com/manaaan/ekolivs-oms/product/internal/product"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -15,9 +15,10 @@ type Server struct {
 }
 
 func (s Server) GetProducts(ctx context.Context, e *emptypb.Empty) (*api.ProductsRes, error) {
+	log, ctx := tlog.New(ctx)
 	products, err := s.ProductService.GetProducts(ctx)
 	if err != nil {
-		slog.Error("Unable to get products")
+		log.Error("Unable to get products")
 		return nil, err
 	}
 
@@ -25,9 +26,10 @@ func (s Server) GetProducts(ctx context.Context, e *emptypb.Empty) (*api.Product
 }
 
 func (s Server) UpdateProduct(ctx context.Context, prod *api.Product) (*api.Product, error) {
+	log, ctx := tlog.New(ctx)
 	p, err := s.ProductService.UpdateProduct(ctx, prod)
 	if err != nil {
-		slog.Error("failed to update product", "error", err)
+		log.Error("failed to update product", "error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Allows better tracing of logs between services, integrates properly to GCP logging structure and extends logged information to help identify the original cause more effectively.

Not using in all locations yet, but only present a test of usage in proudct/server/server.go
This should be extended to all logging locations in the future, once we agree to usage like this.

Resolves #55