### PR TITLE
refactor: mount directly the directory frontend into the container forr dev target

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ./specs:/app/specs
     network_mode: "host"
     # Add when we have a product service Dockerfile
+      - ./frontend:/app/frontend
     depends_on:
       - product
 networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -37,7 +37,6 @@ USER nextjs
 CMD [ "node", "server.js" ]
 
 FROM base AS dev
-COPY ./frontend ./frontend
 WORKDIR /app/frontend
 EXPOSE 3000
 CMD [ "pnpm", "dev" ]


### PR DESCRIPTION
Move the copying instruction from the Dockerfile for the dev target
Add the mount point of Frontend directory into the container at running time
solving the issue #74 