### PR TITLE
Fix/73/1755483545

### DIFF
--- a/backend/services/product/cmd/main.go
+++ b/backend/services/product/cmd/main.go
@@ -24,7 +24,7 @@ func main() {
 	}
 
 	port := 8080
-	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
+	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - ./specs:/app/specs
     network_mode: "host"
     # Add when we have a product service Dockerfile
+      - ./frontend:/app/frontend
     depends_on:
       - product
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,25 +7,25 @@ services:
     volumes:
       - ./secrets/sample.env:/prod/.env
       - ./secrets/firestore-sa.json:/prod/firestore-sa.json
-    network_mode: "host"
+    networks:
+      - internal
   frontend:
     build:
       dockerfile: ./frontend/Dockerfile
       target: dev
-      #args:
-      #  - PRODUCT_SERVICE_HOST=product:8080
     environment:
-      - PRODUCT_SERVICE_HOST=localhost:8080
+      - PRODUCT_SERVICE_HOST=product:8080
       - GRPC_TRACE=all
     ports:
       - "3000:3000"
     volumes:
       - ./specs:/app/specs
-    network_mode: "host"
-    # Add when we have a product service Dockerfile
       - ./frontend:/app/frontend
+    networks:
+      - internal
     depends_on:
       - product
+
 networks:
-  default:
-    enable_ipv6: false
+  internal:
+    driver: bridge

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -37,7 +37,6 @@ USER nextjs
 CMD [ "node", "server.js" ]
 
 FROM base AS dev
-COPY ./frontend ./frontend
 WORKDIR /app/frontend
 EXPOSE 3000
 CMD [ "pnpm", "dev" ]


### PR DESCRIPTION
Changes the bind ip  to 0.0.0.0 since the docker port mapping maps to the container internal address not the localhost of the containers.
Therefore, it allows us to use the internal network for containers. 
solves issue #73 